### PR TITLE
AppleIntelWifiAdapterV2: Fixed issue in hardware address check

### DIFF
--- a/AppleIntelWifiAdapter/AppleIntelWifiAdapterV2.cpp
+++ b/AppleIntelWifiAdapter/AppleIntelWifiAdapterV2.cpp
@@ -401,13 +401,18 @@ IO80211Interface* AppleIntelWifiAdapterV2::getNetworkInterface() {
 }
 
 IOReturn AppleIntelWifiAdapterV2::getHardwareAddress(IOEthernetAddress *addrP) {
-    if(!this->drv->m_pDevice->ie_dev->address[0]) {
-        return kIOReturnError;
+    // Check if address is valid (all zeroes means invalid)
+    for (int i=0;i<ETH_ALEN;i++) {
+        if (this->drv->m_pDevice->ie_dev->address[i]) {
+            // Byte is non-zero, this address must be valid and we can return it
+            memcpy(&addrP->bytes, &this->drv->m_pDevice->ie_dev->address, ETH_ALEN);
+            
+            return kIOReturnSuccess;
+        }
     }
-    else {
-        memcpy(&addrP->bytes, &this->drv->m_pDevice->ie_dev->address, ETH_ALEN);
-    }
-    return kIOReturnSuccess;
+    
+    // Address is all zero, return error
+    return kIOReturnError;
 }
 
 IOReturn AppleIntelWifiAdapterV2::getHardwareAddressForInterface(IO80211Interface* netif, IOEthernetAddress* addr) {


### PR DESCRIPTION
On some cards, `attachInterface()` will fail (`start failed, can not attach interface`) due to the fact that `getHardwareAddress()` only checks whether the first byte of the MAC address is null before returning an error. If a valid MAC address happens to start with 0x00, this causes a false negative that prevents the driver from loading.

This pull request replaces the check with a for loop that checks every byte, only returning an error if all bytes are zero.

Naturally this will only be reliable as an error checker if all the bytes _are_ zero upon failure, and I couldn't tell if the code did this already or if they're left uninitialized until [this memcpy](https://github.com/itsmattkc/adapter/blob/master/AppleIntelWifiAdapter/nvm/IWLNvm.cpp#L470). As such this PR doesn't implement any array initialization/setting to 0, but if the code doesn't do that, I'd be happy to add it to this PR wherever is most appropriate.